### PR TITLE
Json utf experimental

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -25,6 +25,17 @@ module ActionDispatch
         end
       end
 
+      def content_mime_charset
+        fetch_header("action_dispatch.request.content_mime_charset") do |k|
+          v = if get_header("CONTENT_TYPE") =~ /charset=([^()<>@,;:\"\/[\\]?.=\s]*)/i
+                $1.strip.downcase
+              else
+                nil
+              end
+          set_header k, v
+        end
+      end
+
       def content_type
         content_mime_type && content_mime_type.to_s
       end

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -111,6 +111,7 @@ module ActionDispatch
           begin
             strategy.call(raw_post.force_encoding(encoding))
           rescue # JSON or Ruby code block errors
+            raw_post.force_encoding(Encoding::BINARY)
             my_logger = logger || ActiveSupport::Logger.new($stderr)
             my_logger.debug "Error occurred while parsing request parameters.\nContents:\n\n#{raw_post}"
 

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -7,6 +7,15 @@ module ActionDispatch
 
       DEFAULT_PARSERS = {
         Mime[:json].symbol => -> (raw_post) {
+          if raw_post.encoding == Encoding::BINARY
+            # UTF-8 is the default encoding for JSON.
+            raw_post = raw_post.force_encoding(Encoding::UTF_8)
+          end
+
+          unless raw_post.valid_encoding?
+            raise Rack::Utils::InvalidParameterError, "Invalid #{raw_post.encoding.to_s} sequence"
+          end
+
           data = ActiveSupport::JSON.decode(raw_post)
           data.is_a?(Hash) ? data : { _json: data }
         }

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1042,6 +1042,51 @@ class RequestParameters < BaseRequestTest
     assert_raises(ActionController::BadRequest) { request.parameters }
   end
 
+  test "JSON parameter containing an invalid UTF8 sequence (default charset)" do
+    invalid = "{ \"bad\": \"\xBE\" }"
+
+    request = stub_request(
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_LENGTH" => invalid.length,
+        "CONTENT_TYPE" => "application/json",
+        "rack.input" => StringIO.new(invalid)
+    )
+
+    assert_raises(ActionDispatch::Http::Parameters::ParseError) do
+      request.parameters
+    end
+  end
+
+  test "JSON parameter containing an invalid UTF8 sequence (explicit charset)" do
+    invalid = "{ \"bad\": \"\xBE\" }"
+
+    request = stub_request(
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_LENGTH" => invalid.length,
+        "CONTENT_TYPE" => "application/json; charset=utf-8",
+        "rack.input" => StringIO.new(invalid)
+    )
+
+    assert_raises(ActionDispatch::Http::Parameters::ParseError) do
+      request.parameters
+    end
+  end
+
+  test "JSON parameter containing an invalid UTF16 sequence" do
+    invalid = "{ \"bad\": \"\xBE\" }"
+
+    request = stub_request(
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_LENGTH" => invalid.length,
+        "CONTENT_TYPE" => "application/json; charset=UTF-16",
+        "rack.input" => StringIO.new(invalid)
+    )
+
+    assert_raises(ActionDispatch::Http::Parameters::ParseError) do
+      request.parameters
+    end
+  end
+
   test "parameters not accessible after rack parse error 1" do
     request = stub_request(
       "REQUEST_METHOD" => "POST",


### PR DESCRIPTION
WIP

Notes:
- not standard (there's no such a thing like `charset` for `application/json`). http://www.iana.org/assignments/media-types/application/json says that "No "charset" parameter is defined for this registration"
- http://stackoverflow.com/a/14955491 no longer valid as per RFC 7159
- but may still be valid-ish: http://stackoverflow.com/questions/9254891/what-does-content-type-application-json-charset-utf-8-really-mean#comment54557021_14955491
- JSON RFC (new one): https://tools.ietf.org/html/rfc7159#section-8
- detect encoding? http://stackoverflow.com/a/4522251